### PR TITLE
Installation instructions for installing gitin with brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ gitin is a minimalist tool that lets you explore a git repository from command l
 - `cd` into `$GOPATH/src/github.com/isacikgoz/gitin`
 - build with `make install`
 
+### Mac using brew 
+```
+brew tap jeroenknoops/tap
+brew install gitin
+```
+
 ## Usage
 ```bash
 usage: gitin [<flags>] <command> [<args> ...]


### PR DESCRIPTION
Great work. I like it!

I've added gitin as a homebrew package, for easy installation on mac-osx.

It uses my private homebrew-tap instead of homebrew-core, but you are free to include it either as your own homebrew-tap or move it to homebrew-core.

See installation configuration:
https://github.com/JeroenKnoops/homebrew-tap/blob/master/Formula/gitin.rb

Feel free to ignore this if you don't want to include this part of the documentation in your package.