### PR TITLE
feat(branch): Add colour coding on branch list

### DIFF
--- a/cli/rendering.go
+++ b/cli/rendering.go
@@ -30,6 +30,16 @@ func renderItem(item interface{}, matches []int, selected bool) [][]term.Cell {
 	case *git.DiffDelta:
 		line = append(line, stautsText(i.DeltaStatusString()[:1])...)
 		line = append(line, highLightedText(matches, color.FgWhite, i.String())...)
+	case *git.Branch:
+		attr := color.FgWhite
+		headIndicator := ""
+		if i.Head {
+			attr = color.FgGreen
+			headIndicator = " *"
+		} else if i.IsRemote() {
+			attr = color.FgRed
+		}
+		line = append(line, highLightedText(matches, attr, i.String() + headIndicator)...)
 	default:
 		line = append(line, highLightedText(matches, color.FgWhite, fmt.Sprint(item))...)
 	}


### PR DESCRIPTION
This closes #60 

- Local branches are listed in white
- Remote branches are listed in red
- The currently checked out branch appears in green and has a visual indicator

I set ```*``` as an indicator but it could also be something like ```(current)```.

Waiting on your feedback!